### PR TITLE
Allow non-expiring API key and resource recreation

### DIFF
--- a/internal/provider/const.go
+++ b/internal/provider/const.go
@@ -7,7 +7,7 @@ const (
 	api_groups    = "/org/groups"
 	api_auth      = "/authorize"
 	api_s3_suffix = "/s3-access-keys"
-	api_suffix    = "/api/v3"
+	api_suffix    = "/api/v4"
 	api_users     = "/org/users"
 	act           = "action"
 	n_act         = "not_action"

--- a/internal/provider/models_types.go
+++ b/internal/provider/models_types.go
@@ -6,8 +6,9 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 /*
@@ -296,7 +297,7 @@ type S3AccessSecretKey struct {
 }
 
 type UserIDS3AccessSecretKeysCreateJson struct {
-	Expires string `json:"expires"`
+	Expires *string `json:"expires"`
 }
 
 type UserIDS3AllKeysModel struct {

--- a/internal/provider/s3_keys_by_current_user_resource.go
+++ b/internal/provider/s3_keys_by_current_user_resource.go
@@ -169,7 +169,7 @@ func (r *s3AccessSecretKeyCurrentUserResource) Read(ctx context.Context, req res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		
+
 		resp.Diagnostics.AddError(
 			"Error Reading StorageGrid access key",
 			"Could not read StorageGrid access key "+state.AccessKey.ValueString()+": "+err.Error(),

--- a/internal/provider/s3_keys_by_user_id_resource.go
+++ b/internal/provider/s3_keys_by_user_id_resource.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -122,8 +124,16 @@ func (r *s3AccessSecretKeyResource) Create(ctx context.Context, req resource.Cre
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("expires"), &expiresConfig)...)
 	tflog.Debug(ctx, "1. Create to json body and fill it with the passed variables.")
 
-	body := &UserIDS3AccessSecretKeysCreateJson{
-		Expires: expiresConfig.ValueString(),
+	var body *UserIDS3AccessSecretKeysCreateJson = nil
+
+	if expiresConfig.ValueString() == "" {
+		body = &UserIDS3AccessSecretKeysCreateJson{
+			Expires: nil,
+		}
+	} else {
+		body = &UserIDS3AccessSecretKeysCreateJson{
+			Expires: expiresConfig.ValueStringPointer(),
+		}
 	}
 
 	tflog.Debug(ctx, "2. Execute Request against REST api.")
@@ -171,8 +181,13 @@ func (r *s3AccessSecretKeyResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	tflog.Debug(ctx, "1. Get refreshed access key information.")
-	respBody, _, _, err := r.client.SendRequest("GET", api_users+"/"+state.UserUUID.ValueString()+api_s3_suffix+"/"+state.AccessKey.ValueString(), nil, 200)
+	respBody, _, respCode, err := r.client.SendRequest("GET", api_users+"/"+state.UserUUID.ValueString()+api_s3_suffix+"/"+state.AccessKey.ValueString(), nil, 200)
 	if err != nil {
+		if respCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		
 		resp.Diagnostics.AddError(
 			"Error Reading StorageGrid access key",
 			"Could not read StorageGrid access key "+state.AccessKey.ValueString()+": "+err.Error(),

--- a/internal/provider/s3_keys_by_user_id_resource.go
+++ b/internal/provider/s3_keys_by_user_id_resource.go
@@ -124,7 +124,7 @@ func (r *s3AccessSecretKeyResource) Create(ctx context.Context, req resource.Cre
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("expires"), &expiresConfig)...)
 	tflog.Debug(ctx, "1. Create to json body and fill it with the passed variables.")
 
-	var body *UserIDS3AccessSecretKeysCreateJson = nil
+	var body *UserIDS3AccessSecretKeysCreateJson
 
 	if expiresConfig.ValueString() == "" {
 		body = &UserIDS3AccessSecretKeysCreateJson{
@@ -187,7 +187,7 @@ func (r *s3AccessSecretKeyResource) Read(ctx context.Context, req resource.ReadR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		
+
 		resp.Diagnostics.AddError(
 			"Error Reading StorageGrid access key",
 			"Could not read StorageGrid access key "+state.AccessKey.ValueString()+": "+err.Error(),


### PR DESCRIPTION
Hi!
This should address #15 
On top the provider does now recreate missing resources in case they got deleted

Cheers!