### PR TITLE
docs: fix typo in /tests/terraform/bucket/main.tf

### DIFF
--- a/tests/terraform/bucket/main.tf
+++ b/tests/terraform/bucket/main.tf
@@ -76,7 +76,7 @@ output "read_bucket_versioning_status" {
   value = data.storagegrid_bucket_versioning.read.status
 }
 
-# Szenario: Change bucket to which a `bucket_versioning` resource is attached.
+# Scenario: Change bucket to which a `bucket_versioning` resource is attached.
 # 1. After initial apply, un-comment the following resources.
 # 3. Run `terraform apply`.
 #


### PR DESCRIPTION
Hello @dmpe,

I am incredibly sorry for coming back to you on this so late. I was a bit too busy this week, unfortunately.

This small PR fixes the typo I introduced in my latest contribution. There was my native tongue shining through and I didn't notice.