### PR TITLE
fix(s3_keys_by_current_user_resource): expiration date mismatch

### DIFF
--- a/internal/provider/s3_keys_by_current_user_resource.go
+++ b/internal/provider/s3_keys_by_current_user_resource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
+// Ensure provider-defined types fully satisfy framework interfaces.
 var (
 	_ resource.Resource                = &s3AccessSecretKeyCurrentUserResource{}
 	_ resource.ResourceWithConfigure   = &s3AccessSecretKeyCurrentUserResource{}
@@ -34,11 +34,11 @@ type s3AccessSecretKeyCurrentUserResource struct {
 	client *S3GridClient
 }
 
-func (r *s3AccessSecretKeyCurrentUserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *s3AccessSecretKeyCurrentUserResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_s3_access_key_current_user"
 }
 
-func (r *s3AccessSecretKeyCurrentUserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *s3AccessSecretKeyCurrentUserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
@@ -79,7 +79,7 @@ func (r *s3AccessSecretKeyCurrentUserResource) Schema(ctx context.Context, req r
 	}
 }
 
-func (r *s3AccessSecretKeyCurrentUserResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *s3AccessSecretKeyCurrentUserResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
@@ -130,15 +130,21 @@ func (r *s3AccessSecretKeyCurrentUserResource) Create(ctx context.Context, req r
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse response, got error: %s", err))
 		return
 	}
-	fmt.Println(returnBody.Data)
-	tflog.Debug(ctx, "4. Mapping json body back to the state file.")
+
+	tflog.Debug(ctx, "4. Check if expires field is the same data as planned")
+	if expiresConfig.ValueString() != "" && !EqualDates(plan.Expires.ValueString(), returnBody.Data.Expires) {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expiration date received from API differs. Received: %s, Planned: %s", returnBody.Data.Expires, plan.Expires.ValueString()))
+		return
+	}
+
+	tflog.Debug(ctx, "5. Mapping json body back to the state file.")
 	acsKeyData := &S3AccessKeyResourceModel{
 		ID:              types.StringValue(returnBody.Data.ID),
 		AccountId:       types.StringValue(returnBody.Data.AccountId),
 		DisplayName:     types.StringValue(returnBody.Data.DisplayName),
 		UserURN:         types.StringValue(returnBody.Data.UserURN),
 		UserUUID:        types.StringValue(returnBody.Data.UserUUID),
-		Expires:         types.StringValue(returnBody.Data.Expires),
+		Expires:         types.StringValue(plan.Expires.ValueString()),
 		AccessKey:       types.StringValue(returnBody.Data.AccessKey),
 		SecretAccessKey: types.StringValue(returnBody.Data.SecretAccessKey),
 	}
@@ -238,7 +244,7 @@ func (r *s3AccessSecretKeyCurrentUserResource) Read(ctx context.Context, req res
 		DisplayName:     types.StringValue(returnBody.Data.DisplayName),
 		UserURN:         types.StringValue(returnBody.Data.UserURN),
 		UserUUID:        types.StringValue(returnBody.Data.UserUUID),
-		Expires:         types.StringValue(returnBody.Data.Expires),
+		Expires:         state.Expires,
 		AccessKey:       state.AccessKey,
 		SecretAccessKey: state.SecretAccessKey,
 	}
@@ -253,7 +259,7 @@ func (r *s3AccessSecretKeyCurrentUserResource) Read(ctx context.Context, req res
 	}
 }
 
-func (r *s3AccessSecretKeyCurrentUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *s3AccessSecretKeyCurrentUserResource) Update(ctx context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Trace(ctx, "There is nothing to update - cannot be done")
 	resp.Diagnostics.AddError("Not implemented", "There is nothing to update - cannot be done")
 }

--- a/internal/provider/s3_keys_by_current_user_resource_test.go
+++ b/internal/provider/s3_keys_by_current_user_resource_test.go
@@ -1,0 +1,78 @@
+// Copyright github.com/dmpe 2024, 2026
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestS3KeysByCurrentUserResourceWithoutExpirationDate(t *testing.T) {
+	username := fmt.Sprintf("tf-provider-acc-test-user-%d", time.Now().Unix())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"storagegrid": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: fmt.Sprintf(`
+resource "storagegrid_users" "test" {
+	unique_name = "user/%s"
+	full_name   = "%s"
+	member_of   = []
+}
+
+resource "storagegrid_s3_access_key_current_user" "test" {
+	user_uuid = storagegrid_users.test.id
+}
+`, username, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("storagegrid_s3_access_key_current_user.test", "user_uuid"),
+					resource.TestCheckResourceAttr("storagegrid_s3_access_key_current_user.test", "expires", ""),
+				),
+			},
+			// Delete testing is done automatically
+		},
+	})
+}
+
+func TestS3KeysByCurrentUserResourceWithExpirationDate(t *testing.T) {
+	username := fmt.Sprintf("tf-provider-acc-test-user-%d", time.Now().Unix())
+	expirationDate := time.Now().Add(10 * time.Minute).Format("2006-01-02T15:04:05Z")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"storagegrid": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: fmt.Sprintf(`
+resource "storagegrid_users" "test" {
+	unique_name = "user/%s"
+	full_name   = "%s"
+	member_of   = []
+}
+
+resource "storagegrid_s3_access_key_current_user" "test" {
+	user_uuid = storagegrid_users.test.id
+	expires   = "%s"
+}
+`, username, username, expirationDate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("storagegrid_s3_access_key_current_user.test", "user_uuid"),
+					resource.TestCheckResourceAttr("storagegrid_s3_access_key_current_user.test", "expires", expirationDate),
+				),
+			},
+			// Delete testing is done automatically
+		},
+	})
+}


### PR DESCRIPTION
between terraform function and API response.

If a Terraform function was used to get the expiration date, the API response differs.
API response format: 2028-09-04T00:00:00.000Z
Terraform function format: 2028-09-04T00:00:00Z

We parse both dates into Golang-native date structures and compare those to determine if the planed and received dates are equal. If yes, we keep the planned date in the state to prevent inconsistent state after apply errors.

---

This is basically the same fix we already implemented for the `storeagegrid_s3_access_key` resource.

# Tested

Against StorageGrid v11 and v12 in our Lab environment. All acceptance tests pass.